### PR TITLE
Attempt at indenting the source for legibility

### DIFF
--- a/endpoints/songrequest.md
+++ b/endpoints/songrequest.md
@@ -3,936 +3,934 @@
 ## Getting Super Powers
 
 {% hint style="info" %}
-This API is still WIP
+  This API is still WIP
 {% endhint %}
 
 {% api-method method="get" host="https://api.streamelements.com" path="/kappa/v2/songrequest/:channel/settings" %}
-{% api-method-summary %}
-Get settings
-{% endapi-method-summary %}
+  {% api-method-summary %}
+    Get settings
+  {% endapi-method-summary %}
 
-{% api-method-description %}
+  {% api-method-description %}
 
-{% endapi-method-description %}
+  {% endapi-method-description %}
 
-{% api-method-spec %}
-{% api-method-request %}
-{% api-method-path-parameters %}
-{% api-method-parameter name="channel" type="string" required=true %}
-The channels ID
-{% endapi-method-parameter %}
-{% endapi-method-path-parameters %}
+  {% api-method-spec %}
+    {% api-method-request %}
+      {% api-method-path-parameters %}
+        {% api-method-parameter name="channel" type="string" required=true %}
+          The channels ID
+        {% endapi-method-parameter %}
+      {% endapi-method-path-parameters %}
 
-{% api-method-headers %}
-{% api-method-parameter name="Authorization" type="string" required=true %}
-JWT Bearer token
-{% endapi-method-parameter %}
-{% endapi-method-headers %}
-{% endapi-method-request %}
+      {% api-method-headers %}
+        {% api-method-parameter name="Authorization" type="string" required=true %}
+          JWT Bearer token
+        {% endapi-method-parameter %}
+      {% endapi-method-headers %}
+    {% endapi-method-request %}
 
-{% api-method-response %}
-{% api-method-response-example httpCode=200 %}
-{% api-method-response-example-description %}
+    {% api-method-response %}
+      {% api-method-response-example httpCode=200 %}
+        {% api-method-response-example-description %}
 
-{% endapi-method-response-example-description %}
-
-```javascript
-{
-    "player": {
-        "delay": 0
-    },
-    "limits": {
-        "users": {
-            "free": 2,
-            "paid": 10
-        },
-        "queueLimit": 20,
-        "maxDuration": 905
-    },
-    "backupPlaylist": {
-        "url": "",
-        "prioritizeQueue": true
-    },
-    "bot": {
-        "voteskip": {
-            "enabled": false,
-            "votesRequired": 5
-        },
-        "cost": 0,
-        "subscriberDiscount": 0,
-        "exemptUserLevel": 250,
-        "minUserLevel": 100
-    },
-    "tips": {
-        "mediashare": {
-            "enabled": false,
-            "costPerSecond": 0.17
-        },
-        "prioritize": true
-    },
-    "youtube": {
-        "securityLevel": 0,
-        "musicOnly": false,
-        "bannedTags": [],
-        "bannedVideos": [
-            {
-                "_id": "5aef49e6624feef195f67e08",
-                "videoId": "CmFn5Llz5bo",
-                "title": "song for Coral FeelsGoodMan"
-            }
-        ]
-    },
-    "enabled": true,
-    "mode": "combined",
-    "moderation": false,
-    "_id": "5adf59d2490428179d735d6f",
-    "bannedUsers": []
-}
-```
-{% endapi-method-response-example %}
-{% endapi-method-response %}
-{% endapi-method-spec %}
+        {% endapi-method-response-example-description %}
+        ```javascript
+        {
+            "player": {
+                "delay": 0
+            },
+            "limits": {
+                "users": {
+                    "free": 2,
+                    "paid": 10
+                },
+                "queueLimit": 20,
+                "maxDuration": 905
+            },
+            "backupPlaylist": {
+                "url": "",
+                "prioritizeQueue": true
+            },
+            "bot": {
+                "voteskip": {
+                    "enabled": false,
+                    "votesRequired": 5
+                },
+                "cost": 0,
+                "subscriberDiscount": 0,
+                "exemptUserLevel": 250,
+                "minUserLevel": 100
+            },
+            "tips": {
+                "mediashare": {
+                    "enabled": false,
+                    "costPerSecond": 0.17
+                },
+                "prioritize": true
+            },
+            "youtube": {
+                "securityLevel": 0,
+                "musicOnly": false,
+                "bannedTags": [],
+                "bannedVideos": [
+                    {
+                        "_id": "5aef49e6624feef195f67e08",
+                        "videoId": "CmFn5Llz5bo",
+                        "title": "song for Coral FeelsGoodMan"
+                    }
+                ]
+            },
+            "enabled": true,
+            "mode": "combined",
+            "moderation": false,
+            "_id": "5adf59d2490428179d735d6f",
+            "bannedUsers": []
+        }
+        ```
+      {% endapi-method-response-example %}
+    {% endapi-method-response %}
+  {% endapi-method-spec %}
 {% endapi-method %}
 
 {% api-method method="get" host="https://api.streamelements.com" path="/kappa/v2/songrequest/:channel/settings" %}
-{% api-method-summary %}
-Get public settings
-{% endapi-method-summary %}
+  {% api-method-summary %}
+    Get public settings
+  {% endapi-method-summary %}
 
-{% api-method-description %}
+  {% api-method-description %}
 
-{% endapi-method-description %}
+  {% endapi-method-description %}
 
-{% api-method-spec %}
-{% api-method-request %}
-{% api-method-path-parameters %}
-{% api-method-parameter name="channel" type="string" required=false %}
+  {% api-method-spec %}
+    {% api-method-request %}
+      {% api-method-path-parameters %}
+        {% api-method-parameter name="channel" type="string" required=false %}
 
-{% endapi-method-parameter %}
-{% endapi-method-path-parameters %}
-{% endapi-method-request %}
+        {% endapi-method-parameter %}
+      {% endapi-method-path-parameters %}
+    {% endapi-method-request %}
 
-{% api-method-response %}
-{% api-method-response-example httpCode=200 %}
-{% api-method-response-example-description %}
+    {% api-method-response %}
+      {% api-method-response-example httpCode=200 %}
+        {% api-method-response-example-description %}
 
-{% endapi-method-response-example-description %}
+        {% endapi-method-response-example-description %}
 
-```
+        ```
 
-```
-{% endapi-method-response-example %}
-{% endapi-method-response %}
-{% endapi-method-spec %}
+        ```
+      {% endapi-method-response-example %}
+    {% endapi-method-response %}
+  {% endapi-method-spec %}
 {% endapi-method %}
 
 {% api-method method="put" host="" path="" %}
-{% api-method-summary %}
-Update settings
-{% endapi-method-summary %}
+  {% api-method-summary %}
+    Update settings
+  {% endapi-method-summary %}
 
-{% api-method-description %}
+  {% api-method-description %}
 
-{% endapi-method-description %}
+  {% endapi-method-description %}
 
-{% api-method-spec %}
-{% api-method-request %}
-{% api-method-path-parameters %}
-{% api-method-parameter name="" type="string" required=false %}
+  {% api-method-spec %}
+    {% api-method-request %}
+      {% api-method-path-parameters %}
+        {% api-method-parameter name="" type="string" required=false %}
 
-{% endapi-method-parameter %}
-{% endapi-method-path-parameters %}
-{% endapi-method-request %}
+        {% endapi-method-parameter %}
+      {% endapi-method-path-parameters %}
+    {% endapi-method-request %}
 
-{% api-method-response %}
-{% api-method-response-example httpCode=200 %}
-{% api-method-response-example-description %}
+    {% api-method-response %}
+      {% api-method-response-example httpCode=200 %}
+        {% api-method-response-example-description %}
 
-{% endapi-method-response-example-description %}
+        {% endapi-method-response-example-description %}
 
-```
+        ```
 
-```
-{% endapi-method-response-example %}
-{% endapi-method-response %}
-{% endapi-method-spec %}
+        ```
+      {% endapi-method-response-example %}
+    {% endapi-method-response %}
+  {% endapi-method-spec %}
 {% endapi-method %}
 
 {% api-method method="get" host="" path="" %}
-{% api-method-summary %}
-Get the queue
-{% endapi-method-summary %}
+  {% api-method-summary %}
+    Get the queue
+  {% endapi-method-summary %}
 
-{% api-method-description %}
+  {% api-method-description %}
 
-{% endapi-method-description %}
+  {% endapi-method-description %}
 
-{% api-method-spec %}
-{% api-method-request %}
-{% api-method-path-parameters %}
-{% api-method-parameter name="" type="string" required=false %}
+  {% api-method-spec %}
+    {% api-method-request %}
+      {% api-method-path-parameters %}
+        {% api-method-parameter name="" type="string" required=false %}
 
-{% endapi-method-parameter %}
-{% endapi-method-path-parameters %}
-{% endapi-method-request %}
+        {% endapi-method-parameter %}
+      {% endapi-method-path-parameters %}
+    {% endapi-method-request %}
 
-{% api-method-response %}
-{% api-method-response-example httpCode=200 %}
-{% api-method-response-example-description %}
+    {% api-method-response %}
+      {% api-method-response-example httpCode=200 %}
+        {% api-method-response-example-description %}
 
-{% endapi-method-response-example-description %}
+        {% endapi-method-response-example-description %}
 
-```
+        ```
 
-```
-{% endapi-method-response-example %}
-{% endapi-method-response %}
-{% endapi-method-spec %}
+        ```
+      {% endapi-method-response-example %}
+    {% endapi-method-response %}
+  {% endapi-method-spec %}
 {% endapi-method %}
 
 {% api-method method="get" host="" path="" %}
-{% api-method-summary %}
-Get the public queue
-{% endapi-method-summary %}
+  {% api-method-summary %}
+    Get the public queue
+  {% endapi-method-summary %}
 
-{% api-method-description %}
+  {% api-method-description %}
 
-{% endapi-method-description %}
+  {% endapi-method-description %}
 
-{% api-method-spec %}
-{% api-method-request %}
-{% api-method-path-parameters %}
-{% api-method-parameter name="" type="string" required=false %}
+  {% api-method-spec %}
+    {% api-method-request %}
+      {% api-method-path-parameters %}
+        {% api-method-parameter name="" type="string" required=false %}
 
-{% endapi-method-parameter %}
-{% endapi-method-path-parameters %}
-{% endapi-method-request %}
+        {% endapi-method-parameter %}
+      {% endapi-method-path-parameters %}
+    {% endapi-method-request %}
 
-{% api-method-response %}
-{% api-method-response-example httpCode=200 %}
-{% api-method-response-example-description %}
+    {% api-method-response %}
+      {% api-method-response-example httpCode=200 %}
+        {% api-method-response-example-description %}
 
-{% endapi-method-response-example-description %}
+        {% endapi-method-response-example-description %}
 
-```
+        ```
 
-```
-{% endapi-method-response-example %}
-{% endapi-method-response %}
-{% endapi-method-spec %}
+        ```
+      {% endapi-method-response-example %}
+    {% endapi-method-response %}
+  {% endapi-method-spec %}
 {% endapi-method %}
 
 {% api-method method="get" host="" path="" %}
-{% api-method-summary %}
-Get the pending queue
-{% endapi-method-summary %}
+  {% api-method-summary %}
+    Get the pending queue
+  {% endapi-method-summary %}
 
-{% api-method-description %}
+  {% api-method-description %}
 
-{% endapi-method-description %}
+  {% endapi-method-description %}
 
-{% api-method-spec %}
-{% api-method-request %}
-{% api-method-path-parameters %}
-{% api-method-parameter name="" type="string" required=false %}
+  {% api-method-spec %}
+    {% api-method-request %}
+      {% api-method-path-parameters %}
+        {% api-method-parameter name="" type="string" required=false %}
 
-{% endapi-method-parameter %}
-{% endapi-method-path-parameters %}
-{% endapi-method-request %}
+        {% endapi-method-parameter %}
+      {% endapi-method-path-parameters %}
+    {% endapi-method-request %}
 
-{% api-method-response %}
-{% api-method-response-example httpCode=200 %}
-{% api-method-response-example-description %}
+    {% api-method-response %}
+      {% api-method-response-example httpCode=200 %}
+        {% api-method-response-example-description %}
 
-{% endapi-method-response-example-description %}
+        {% endapi-method-response-example-description %}
 
-```
+        ```
 
-```
-{% endapi-method-response-example %}
-{% endapi-method-response %}
-{% endapi-method-spec %}
+        ```
+      {% endapi-method-response-example %}
+    {% endapi-method-response %}
+  {% endapi-method-spec %}
 {% endapi-method %}
 
 {% api-method method="delete" host="" path="" %}
-{% api-method-summary %}
-Clear the pending queue
-{% endapi-method-summary %}
+  {% api-method-summary %}
+    Clear the pending queue
+  {% endapi-method-summary %}
 
-{% api-method-description %}
+  {% api-method-description %}
 
-{% endapi-method-description %}
+  {% endapi-method-description %}
 
-{% api-method-spec %}
-{% api-method-request %}
-{% api-method-path-parameters %}
-{% api-method-parameter name="" type="string" required=false %}
+  {% api-method-spec %}
+    {% api-method-request %}
+      {% api-method-path-parameters %}
+        {% api-method-parameter name="" type="string" required=false %}
 
-{% endapi-method-parameter %}
-{% endapi-method-path-parameters %}
-{% endapi-method-request %}
+        {% endapi-method-parameter %}
+      {% endapi-method-path-parameters %}
+    {% endapi-method-request %}
 
-{% api-method-response %}
-{% api-method-response-example httpCode=200 %}
-{% api-method-response-example-description %}
+    {% api-method-response %}
+      {% api-method-response-example httpCode=200 %}
+        {% api-method-response-example-description %}
 
-{% endapi-method-response-example-description %}
+        {% endapi-method-response-example-description %}
 
-```
+        ```
 
-```
-{% endapi-method-response-example %}
-{% endapi-method-response %}
-{% endapi-method-spec %}
+        ```
+      {% endapi-method-response-example %}
+    {% endapi-method-response %}
+  {% endapi-method-spec %}
 {% endapi-method %}
 
 {% api-method method="get" host="" path="" %}
-{% api-method-summary %}
-Get the backup playlist
-{% endapi-method-summary %}
+  {% api-method-summary %}
+    Get the backup playlist
+  {% endapi-method-summary %}
 
-{% api-method-description %}
+  {% api-method-description %}
 
-{% endapi-method-description %}
+  {% endapi-method-description %}
 
-{% api-method-spec %}
-{% api-method-request %}
-{% api-method-path-parameters %}
-{% api-method-parameter name="" type="string" required=false %}
+  {% api-method-spec %}
+    {% api-method-request %}
+      {% api-method-path-parameters %}
+        {% api-method-parameter name="" type="string" required=false %}
 
-{% endapi-method-parameter %}
-{% endapi-method-path-parameters %}
-{% endapi-method-request %}
+        {% endapi-method-parameter %}
+      {% endapi-method-path-parameters %}
+    {% endapi-method-request %}
 
-{% api-method-response %}
-{% api-method-response-example httpCode=200 %}
-{% api-method-response-example-description %}
+    {% api-method-response %}
+      {% api-method-response-example httpCode=200 %}
+        {% api-method-response-example-description %}
 
-{% endapi-method-response-example-description %}
+        {% endapi-method-response-example-description %}
 
-```
+        ```
 
-```
-{% endapi-method-response-example %}
-{% endapi-method-response %}
-{% endapi-method-spec %}
+        ```
+      {% endapi-method-response-example %}
+    {% endapi-method-response %}
+  {% endapi-method-spec %}
 {% endapi-method %}
 
 {% api-method method="post" host="" path="/:channel/skip" %}
-{% api-method-summary %}
-Skip the current song
-{% endapi-method-summary %}
+  {% api-method-summary %}
+    Skip the current song
+  {% endapi-method-summary %}
 
-{% api-method-description %}
+  {% api-method-description %}
 
-{% endapi-method-description %}
+  {% endapi-method-description %}
 
-{% api-method-spec %}
-{% api-method-request %}
-{% api-method-path-parameters %}
-{% api-method-parameter name="" type="string" required=false %}
+  {% api-method-spec %}
+    {% api-method-request %}
+      {% api-method-path-parameters %}
+        {% api-method-parameter name="" type="string" required=false %}
 
-{% endapi-method-parameter %}
-{% endapi-method-path-parameters %}
-{% endapi-method-request %}
+        {% endapi-method-parameter %}
+      {% endapi-method-path-parameters %}
+    {% endapi-method-request %}
 
-{% api-method-response %}
-{% api-method-response-example httpCode=200 %}
-{% api-method-response-example-description %}
+    {% api-method-response %}
+      {% api-method-response-example httpCode=200 %}
+        {% api-method-response-example-description %}
 
-{% endapi-method-response-example-description %}
+        {% endapi-method-response-example-description %}
 
-```
+        ```
 
-```
-{% endapi-method-response-example %}
-{% endapi-method-response %}
-{% endapi-method-spec %}
+        ```
+      {% endapi-method-response-example %}
+    {% endapi-method-response %}
+  {% endapi-method-spec %}
 {% endapi-method %}
 
 {% api-method method="get" host="" path="/:channel/player" %}
-{% api-method-summary %}
+  {% api-method-summary %}
 
-{% endapi-method-summary %}
+  {% endapi-method-summary %}
 
-{% api-method-description %}
+  {% api-method-description %}
 
-{% endapi-method-description %}
+  {% endapi-method-description %}
 
-{% api-method-spec %}
-{% api-method-request %}
-{% api-method-path-parameters %}
-{% api-method-parameter name="" type="string" required=false %}
+  {% api-method-spec %}
+    {% api-method-request %}
+      {% api-method-path-parameters %}
+        {% api-method-parameter name="" type="string" required=false %}
 
-{% endapi-method-parameter %}
-{% endapi-method-path-parameters %}
-{% endapi-method-request %}
+        {% endapi-method-parameter %}
+      {% endapi-method-path-parameters %}
+    {% endapi-method-request %}
 
-{% api-method-response %}
-{% api-method-response-example httpCode=200 %}
-{% api-method-response-example-description %}
+    {% api-method-response %}
+      {% api-method-response-example httpCode=200 %}
+        {% api-method-response-example-description %}
 
-{% endapi-method-response-example-description %}
+        {% endapi-method-response-example-description %}
 
-```
+        ```
 
-```
-{% endapi-method-response-example %}
-{% endapi-method-response %}
-{% endapi-method-spec %}
+        ```
+      {% endapi-method-response-example %}
+    {% endapi-method-response %}
+  {% endapi-method-spec %}
 {% endapi-method %}
 
 {% api-method method="post" host="" path="" %}
-{% api-method-summary %}
-Set the player state
-{% endapi-method-summary %}
+  {% api-method-summary %}
+    Set the player state
+  {% endapi-method-summary %}
 
-{% api-method-description %}
+  {% api-method-description %}
 
-{% endapi-method-description %}
+  {% endapi-method-description %}
 
-{% api-method-spec %}
-{% api-method-request %}
-{% api-method-path-parameters %}
-{% api-method-parameter name="" type="string" required=false %}
+  {% api-method-spec %}
+    {% api-method-request %}
+      {% api-method-path-parameters %}
+        {% api-method-parameter name="" type="string" required=false %}
 
-{% endapi-method-parameter %}
-{% endapi-method-path-parameters %}
-{% endapi-method-request %}
+        {% endapi-method-parameter %}
+      {% endapi-method-path-parameters %}
+    {% endapi-method-request %}
 
-{% api-method-response %}
-{% api-method-response-example httpCode=200 %}
-{% api-method-response-example-description %}
+    {% api-method-response %}
+      {% api-method-response-example httpCode=200 %}
+        {% api-method-response-example-description %}
 
-{% endapi-method-response-example-description %}
+        {% endapi-method-response-example-description %}
 
-```
+        ```
 
-```
-{% endapi-method-response-example %}
-{% endapi-method-response %}
-{% endapi-method-spec %}
+        ```
+      {% endapi-method-response-example %}
+    {% endapi-method-response %}
+  {% endapi-method-spec %}
 {% endapi-method %}
 
 {% api-method method="post" host="" path="" %}
-{% api-method-summary %}
-Play the next song
-{% endapi-method-summary %}
+  {% api-method-summary %}
+    Play the next song
+  {% endapi-method-summary %}
 
-{% api-method-description %}
+  {% api-method-description %}
 
-{% endapi-method-description %}
+  {% endapi-method-description %}
 
-{% api-method-spec %}
-{% api-method-request %}
-{% api-method-path-parameters %}
-{% api-method-parameter name="" type="string" required=false %}
+  {% api-method-spec %}
+    {% api-method-request %}
+      {% api-method-path-parameters %}
+        {% api-method-parameter name="" type="string" required=false %}
 
-{% endapi-method-parameter %}
-{% endapi-method-path-parameters %}
-{% endapi-method-request %}
+        {% endapi-method-parameter %}
+      {% endapi-method-path-parameters %}
+    {% endapi-method-request %}
 
-{% api-method-response %}
-{% api-method-response-example httpCode=200 %}
-{% api-method-response-example-description %}
+    {% api-method-response %}
+      {% api-method-response-example httpCode=200 %}
+        {% api-method-response-example-description %}
 
-{% endapi-method-response-example-description %}
+        {% endapi-method-response-example-description %}
 
-```
+        ```
 
-```
-{% endapi-method-response-example %}
-{% endapi-method-response %}
-{% endapi-method-spec %}
+        ```
+      {% endapi-method-response-example %}
+    {% endapi-method-response %}
+  {% endapi-method-spec %}
 {% endapi-method %}
 
 {% api-method method="post" host="" path="/kappa/v2/:channel/pending/:songId/approve" %}
-{% api-method-summary %}
-Approve a pending song
-{% endapi-method-summary %}
+  {% api-method-summary %}
+    Approve a pending song
+  {% endapi-method-summary %}
 
-{% api-method-description %}
+  {% api-method-description %}
 
-{% endapi-method-description %}
+  {% endapi-method-description %}
 
-{% api-method-spec %}
-{% api-method-request %}
-{% api-method-path-parameters %}
-{% api-method-parameter name="" type="string" required=false %}
+  {% api-method-spec %}
+    {% api-method-request %}
+      {% api-method-path-parameters %}
+        {% api-method-parameter name="" type="string" required=false %}
 
-{% endapi-method-parameter %}
-{% endapi-method-path-parameters %}
-{% endapi-method-request %}
+        {% endapi-method-parameter %}
+      {% endapi-method-path-parameters %}
+    {% endapi-method-request %}
 
-{% api-method-response %}
-{% api-method-response-example httpCode=200 %}
-{% api-method-response-example-description %}
+    {% api-method-response %}
+      {% api-method-response-example httpCode=200 %}
+        {% api-method-response-example-description %}
 
-{% endapi-method-response-example-description %}
+        {% endapi-method-response-example-description %}
 
-```
+        ```
 
-```
-{% endapi-method-response-example %}
-{% endapi-method-response %}
-{% endapi-method-spec %}
+        ```
+      {% endapi-method-response-example %}
+    {% endapi-method-response %}
+  {% endapi-method-spec %}
 {% endapi-method %}
 
 {% api-method method="post" host="https://api.streamelements.com" path="/kappa/v2/songrequest/:channel/pending/:songId/reject" %}
-{% api-method-summary %}
-Reject a pending song
-{% endapi-method-summary %}
+  {% api-method-summary %}
+    Reject a pending song
+  {% endapi-method-summary %}
 
-{% api-method-description %}
+  {% api-method-description %}
 
-{% endapi-method-description %}
+  {% endapi-method-description %}
 
-{% api-method-spec %}
-{% api-method-request %}
-{% api-method-path-parameters %}
-{% api-method-parameter name="" type="string" required=false %}
+  {% api-method-spec %}
+    {% api-method-request %}
+      {% api-method-path-parameters %}
+        {% api-method-parameter name="" type="string" required=false %}
 
-{% endapi-method-parameter %}
-{% endapi-method-path-parameters %}
-{% endapi-method-request %}
+        {% endapi-method-parameter %}
+      {% endapi-method-path-parameters %}
+    {% endapi-method-request %}
 
-{% api-method-response %}
-{% api-method-response-example httpCode=200 %}
-{% api-method-response-example-description %}
+    {% api-method-response %}
+      {% api-method-response-example httpCode=200 %}
+        {% api-method-response-example-description %}
 
-{% endapi-method-response-example-description %}
+        {% endapi-method-response-example-description %}
 
-```
+        ```
 
-```
-{% endapi-method-response-example %}
-{% endapi-method-response %}
-{% endapi-method-spec %}
+        ```
+      {% endapi-method-response-example %}
+    {% endapi-method-response %}
+  {% endapi-method-spec %}
 {% endapi-method %}
 
 {% api-method method="post" host="https://api.streamelements.com" path="/kappa/v2/:channel/pending/approve" %}
-{% api-method-summary %}
-Approve the entire pending queue
-{% endapi-method-summary %}
+  {% api-method-summary %}
+    Approve the entire pending queue
+  {% endapi-method-summary %}
 
-{% api-method-description %}
+  {% api-method-description %}
 
-{% endapi-method-description %}
+  {% endapi-method-description %}
 
-{% api-method-spec %}
-{% api-method-request %}
-{% api-method-path-parameters %}
-{% api-method-parameter name="" type="string" required=false %}
+  {% api-method-spec %}
+    {% api-method-request %}
+      {% api-method-path-parameters %}
+        {% api-method-parameter name="" type="string" required=false %}
 
-{% endapi-method-parameter %}
-{% endapi-method-path-parameters %}
-{% endapi-method-request %}
+        {% endapi-method-parameter %}
+      {% endapi-method-path-parameters %}
+    {% endapi-method-request %}
 
-{% api-method-response %}
-{% api-method-response-example httpCode=200 %}
-{% api-method-response-example-description %}
+    {% api-method-response %}
+      {% api-method-response-example httpCode=200 %}
+        {% api-method-response-example-description %}
 
-{% endapi-method-response-example-description %}
+        {% endapi-method-response-example-description %}
 
-```
+        ```
 
-```
-{% endapi-method-response-example %}
-{% endapi-method-response %}
-{% endapi-method-spec %}
+        ```
+      {% endapi-method-response-example %}
+    {% endapi-method-response %}
+  {% endapi-method-spec %}
 {% endapi-method %}
 
 {% api-method method="post" host="https://api.streamelements.com" path="/kappa/v2/:channel/pending/reject" %}
-{% api-method-summary %}
-Reject the entire pending queue
-{% endapi-method-summary %}
+  {% api-method-summary %}
+    Reject the entire pending queue
+  {% endapi-method-summary %}
 
-{% api-method-description %}
+  {% api-method-description %}
 
-{% endapi-method-description %}
+  {% endapi-method-description %}
 
-{% api-method-spec %}
-{% api-method-request %}
-{% api-method-path-parameters %}
-{% api-method-parameter name="" type="string" required=false %}
+  {% api-method-spec %}
+    {% api-method-request %}
+      {% api-method-path-parameters %}
+        {% api-method-parameter name="" type="string" required=false %}
 
-{% endapi-method-parameter %}
-{% endapi-method-path-parameters %}
-{% endapi-method-request %}
+        {% endapi-method-parameter %}
+      {% endapi-method-path-parameters %}
+    {% endapi-method-request %}
 
-{% api-method-response %}
-{% api-method-response-example httpCode=200 %}
-{% api-method-response-example-description %}
+    {% api-method-response %}
+      {% api-method-response-example httpCode=200 %}
+        {% api-method-response-example-description %}
 
-{% endapi-method-response-example-description %}
+        {% endapi-method-response-example-description %}
 
-```
+        ```
 
-```
-{% endapi-method-response-example %}
-{% endapi-method-response %}
-{% endapi-method-spec %}
+        ```
+      {% endapi-method-response-example %}
+    {% endapi-method-response %}
+  {% endapi-method-spec %}
 {% endapi-method %}
 
 {% api-method method="post" host="https://api.streamelements.com" path="/kappa/v2/:channel/queue" %}
-{% api-method-summary %}
-Add song to the queue
-{% endapi-method-summary %}
+  {% api-method-summary %}
+    Add song to the queue
+  {% endapi-method-summary %}
 
-{% api-method-description %}
+  {% api-method-description %}
 
-{% endapi-method-description %}
+  {% endapi-method-description %}
 
-{% api-method-spec %}
-{% api-method-request %}
-{% api-method-path-parameters %}
-{% api-method-parameter name="" type="string" required=false %}
+  {% api-method-spec %}
+    {% api-method-request %}
+      {% api-method-path-parameters %}
+        {% api-method-parameter name="" type="string" required=false %}
 
-{% endapi-method-parameter %}
-{% endapi-method-path-parameters %}
-{% endapi-method-request %}
+        {% endapi-method-parameter %}
+      {% endapi-method-path-parameters %}
+    {% endapi-method-request %}
 
-{% api-method-response %}
-{% api-method-response-example httpCode=200 %}
-{% api-method-response-example-description %}
+    {% api-method-response %}
+      {% api-method-response-example httpCode=200 %}
+        {% api-method-response-example-description %}
 
-{% endapi-method-response-example-description %}
+        {% endapi-method-response-example-description %}
 
-```
+        ```
 
-```
-{% endapi-method-response-example %}
-{% endapi-method-response %}
-{% endapi-method-spec %}
+        ```
+      {% endapi-method-response-example %}
+    {% endapi-method-response %}
+  {% endapi-method-spec %}
 {% endapi-method %}
 
 {% api-method method="get" host="https://api.streamelements.com" path="/kappa/v2/:channel/queue/:songId" %}
-{% api-method-summary %}
-Get a single song from the queue
-{% endapi-method-summary %}
+  {% api-method-summary %}
+    Get a single song from the queue
+  {% endapi-method-summary %}
 
-{% api-method-description %}
+  {% api-method-description %}
 
-{% endapi-method-description %}
+  {% endapi-method-description %}
 
-{% api-method-spec %}
-{% api-method-request %}
-{% api-method-path-parameters %}
-{% api-method-parameter name="" type="string" required=false %}
+  {% api-method-spec %}
+    {% api-method-request %}
+      {% api-method-path-parameters %}
+        {% api-method-parameter name="" type="string" required=false %}
 
-{% endapi-method-parameter %}
-{% endapi-method-path-parameters %}
-{% endapi-method-request %}
+        {% endapi-method-parameter %}
+      {% endapi-method-path-parameters %}
+    {% endapi-method-request %}
 
-{% api-method-response %}
-{% api-method-response-example httpCode=200 %}
-{% api-method-response-example-description %}
+    {% api-method-response %}
+      {% api-method-response-example httpCode=200 %}
+        {% api-method-response-example-description %}
 
-{% endapi-method-response-example-description %}
+        {% endapi-method-response-example-description %}
 
-```
+        ```
 
-```
-{% endapi-method-response-example %}
-{% endapi-method-response %}
-{% endapi-method-spec %}
+        ```
+      {% endapi-method-response-example %}
+    {% endapi-method-response %}
+  {% endapi-method-spec %}
 {% endapi-method %}
 
 {% api-method method="put" host="https://api.streamelements.com" path="/kappa/v2/:channel/queue/:songId" %}
-{% api-method-summary %}
-Update a songs position in the queue
-{% endapi-method-summary %}
+  {% api-method-summary %}
+    Update a songs position in the queue
+  {% endapi-method-summary %}
 
-{% api-method-description %}
+  {% api-method-description %}
 
-{% endapi-method-description %}
+  {% endapi-method-description %}
 
-{% api-method-spec %}
-{% api-method-request %}
-{% api-method-path-parameters %}
-{% api-method-parameter name="channel" type="string" required=false %}
+  {% api-method-spec %}
+    {% api-method-request %}
+      {% api-method-path-parameters %}
+        {% api-method-parameter name="channel" type="string" required=false %}
 
-{% endapi-method-parameter %}
+        {% endapi-method-parameter %}
 
-{% api-method-parameter name="songId" type="string" required=false %}
+        {% api-method-parameter name="songId" type="string" required=false %}
 
-{% endapi-method-parameter %}
-{% endapi-method-path-parameters %}
+        {% endapi-method-parameter %}
+      {% endapi-method-path-parameters %}
 
-{% api-method-body-parameters %}
-{% api-method-parameter name="position" type="number" required=true %}
-The position to move the song.
-{% endapi-method-parameter %}
-{% endapi-method-body-parameters %}
-{% endapi-method-request %}
+      {% api-method-body-parameters %}
+        {% api-method-parameter name="position" type="number" required=true %}
+          The position to move the song.
+        {% endapi-method-parameter %}
+      {% endapi-method-body-parameters %}
+    {% endapi-method-request %}
 
-{% api-method-response %}
-{% api-method-response-example httpCode=200 %}
-{% api-method-response-example-description %}
+    {% api-method-response %}
+      {% api-method-response-example httpCode=200 %}
+        {% api-method-response-example-description %}
 
-{% endapi-method-response-example-description %}
+        {% endapi-method-response-example-description %}
 
-```
+        ```
 
-```
-{% endapi-method-response-example %}
-{% endapi-method-response %}
-{% endapi-method-spec %}
+        ```
+      {% endapi-method-response-example %}
+    {% endapi-method-response %}
+  {% endapi-method-spec %}
 {% endapi-method %}
 
 {% api-method method="delete" host="https://api.streamelements.com" path="/kappa/v2/:channel/queue/:songId" %}
-{% api-method-summary %}
-Remove a song from the queue
-{% endapi-method-summary %}
+  {% api-method-summary %}
+    Remove a song from the queue
+  {% endapi-method-summary %}
 
-{% api-method-description %}
+  {% api-method-description %}
 
-{% endapi-method-description %}
+  {% endapi-method-description %}
 
-{% api-method-spec %}
-{% api-method-request %}
-{% api-method-path-parameters %}
-{% api-method-parameter name="" type="string" required=false %}
+  {% api-method-spec %}
+    {% api-method-request %}
+      {% api-method-path-parameters %}
+        {% api-method-parameter name="" type="string" required=false %}
 
-{% endapi-method-parameter %}
-{% endapi-method-path-parameters %}
-{% endapi-method-request %}
+        {% endapi-method-parameter %}
+      {% endapi-method-path-parameters %}
+    {% endapi-method-request %}
 
-{% api-method-response %}
-{% api-method-response-example httpCode=200 %}
-{% api-method-response-example-description %}
+    {% api-method-response %}
+      {% api-method-response-example httpCode=200 %}
+        {% api-method-response-example-description %}
 
-{% endapi-method-response-example-description %}
+        {% endapi-method-response-example-description %}
 
-```
+        ```
 
-```
-{% endapi-method-response-example %}
-{% endapi-method-response %}
-{% endapi-method-spec %}
+        ```
+      {% endapi-method-response-example %}
+    {% endapi-method-response %}
+  {% endapi-method-spec %}
 {% endapi-method %}
 
 {% api-method method="delete" host="https://api.streamelements.com" path="/kappa/v2/:channel/queue" %}
-{% api-method-summary %}
-Clear the entire queue
-{% endapi-method-summary %}
+  {% api-method-summary %}
+    Clear the entire queue
+  {% endapi-method-summary %}
 
-{% api-method-description %}
+  {% api-method-description %}
 
-{% endapi-method-description %}
+  {% endapi-method-description %}
 
-{% api-method-spec %}
-{% api-method-request %}
-{% api-method-path-parameters %}
-{% api-method-parameter name="" type="string" required=false %}
+  {% api-method-spec %}
+    {% api-method-request %}
+      {% api-method-path-parameters %}
+        {% api-method-parameter name="" type="string" required=false %}
 
-{% endapi-method-parameter %}
-{% endapi-method-path-parameters %}
-{% endapi-method-request %}
+        {% endapi-method-parameter %}
+      {% endapi-method-path-parameters %}
+    {% endapi-method-request %}
 
-{% api-method-response %}
-{% api-method-response-example httpCode=200 %}
-{% api-method-response-example-description %}
+    {% api-method-response %}
+      {% api-method-response-example httpCode=200 %}
+        {% api-method-response-example-description %}
 
-{% endapi-method-response-example-description %}
+        {% endapi-method-response-example-description %}
 
-```
+        ```
 
-```
-{% endapi-method-response-example %}
-{% endapi-method-response %}
-{% endapi-method-spec %}
+        ```
+      {% endapi-method-response-example %}
+    {% endapi-method-response %}
+  {% endapi-method-spec %}
 {% endapi-method %}
 
 {% api-method method="delete" host="https://api.streamelements.com" path="/kappa/v2/:channel/history" %}
-{% api-method-summary %}
-Get the history of playing songs
-{% endapi-method-summary %}
+  {% api-method-summary %}
+    Get the history of playing songs
+  {% endapi-method-summary %}
 
-{% api-method-description %}
+  {% api-method-description %}
 
-{% endapi-method-description %}
+  {% endapi-method-description %}
 
-{% api-method-spec %}
-{% api-method-request %}
-{% api-method-path-parameters %}
-{% api-method-parameter name="" type="string" required=false %}
+  {% api-method-spec %}
+    {% api-method-request %}
+      {% api-method-path-parameters %}
+        {% api-method-parameter name="" type="string" required=false %}
 
-{% endapi-method-parameter %}
-{% endapi-method-path-parameters %}
-{% endapi-method-request %}
+        {% endapi-method-parameter %}
+      {% endapi-method-path-parameters %}
+    {% endapi-method-request %}
 
-{% api-method-response %}
-{% api-method-response-example httpCode=200 %}
-{% api-method-response-example-description %}
+    {% api-method-response %}
+      {% api-method-response-example httpCode=200 %}
+        {% api-method-response-example-description %}
 
-{% endapi-method-response-example-description %}
+        {% endapi-method-response-example-description %}
 
-```
+        ```
 
-```
-{% endapi-method-response-example %}
-{% endapi-method-response %}
-{% endapi-method-spec %}
+        ```
+      {% endapi-method-response-example %}
+    {% endapi-method-response %}
+  {% endapi-method-spec %}
 {% endapi-method %}
 
 {% api-method method="delete" host="https://api.streamelements.com" path="/kappa/v2/songrequest/:channel/history/:songId" %}
-{% api-method-summary %}
-Clear a single entry from the song history
-{% endapi-method-summary %}
+  {% api-method-summary %}
+    Clear a single entry from the song history
+  {% endapi-method-summary %}
 
-{% api-method-description %}
+  {% api-method-description %}
 
-{% endapi-method-description %}
+  {% endapi-method-description %}
 
-{% api-method-spec %}
-{% api-method-request %}
-{% api-method-path-parameters %}
-{% api-method-parameter name="" type="string" required=false %}
+  {% api-method-spec %}
+    {% api-method-request %}
+      {% api-method-path-parameters %}
+        {% api-method-parameter name="" type="string" required=false %}
 
-{% endapi-method-parameter %}
-{% endapi-method-path-parameters %}
-{% endapi-method-request %}
+        {% endapi-method-parameter %}
+      {% endapi-method-path-parameters %}
+    {% endapi-method-request %}
 
-{% api-method-response %}
-{% api-method-response-example httpCode=200 %}
-{% api-method-response-example-description %}
+    {% api-method-response %}
+      {% api-method-response-example httpCode=200 %}
+        {% api-method-response-example-description %}
 
-{% endapi-method-response-example-description %}
+        {% endapi-method-response-example-description %}
 
-```
+        ```
 
-```
-{% endapi-method-response-example %}
-{% endapi-method-response %}
-{% endapi-method-spec %}
+        ```
+      {% endapi-method-response-example %}
+    {% endapi-method-response %}
+  {% endapi-method-spec %}
 {% endapi-method %}
 
 {% api-method method="get" host="https://api.streamelements.com" path="/kappa/v2/songrequest/:channel/playing" %}
-{% api-method-summary %}
-Get currently playing
-{% endapi-method-summary %}
+  {% api-method-summary %}
+    Get currently playing
+  {% endapi-method-summary %}
 
-{% api-method-description %}
+  {% api-method-description %}
 
-{% endapi-method-description %}
+  {% endapi-method-description %}
 
-{% api-method-spec %}
-{% api-method-request %}
-{% api-method-path-parameters %}
-{% api-method-parameter name="" type="string" required=false %}
+  {% api-method-spec %}
+    {% api-method-request %}
+      {% api-method-path-parameters %}
+        {% api-method-parameter name="" type="string" required=false %}
 
-{% endapi-method-parameter %}
-{% endapi-method-path-parameters %}
-{% endapi-method-request %}
+        {% endapi-method-parameter %}
+      {% endapi-method-path-parameters %}
+    {% endapi-method-request %}
 
-{% api-method-response %}
-{% api-method-response-example httpCode=200 %}
-{% api-method-response-example-description %}
+    {% api-method-response %}
+      {% api-method-response-example httpCode=200 %}
+        {% api-method-response-example-description %}
 
-{% endapi-method-response-example-description %}
+        {% endapi-method-response-example-description %}
 
-```
+        ```
 
-```
-{% endapi-method-response-example %}
-{% endapi-method-response %}
-{% endapi-method-spec %}
+        ```
+      {% endapi-method-response-example %}
+    {% endapi-method-response %}
+  {% endapi-method-spec %}
 {% endapi-method %}
 
 {% api-method method="put" host="https://api.streamelements.com" path="/kappa/v2/songrequest/:channel/playing" %}
-{% api-method-summary %}
-Set currently playing
-{% endapi-method-summary %}
+  {% api-method-summary %}
+    Set currently playing
+  {% endapi-method-summary %}
 
-{% api-method-description %}
+  {% api-method-description %}
 
-{% endapi-method-description %}
+  {% endapi-method-description %}
 
-{% api-method-spec %}
-{% api-method-request %}
-{% api-method-path-parameters %}
-{% api-method-parameter name="" type="string" required=false %}
+  {% api-method-spec %}
+    {% api-method-request %}
+      {% api-method-path-parameters %}
+        {% api-method-parameter name="" type="string" required=false %}
 
-{% endapi-method-parameter %}
-{% endapi-method-path-parameters %}
-{% endapi-method-request %}
+        {% endapi-method-parameter %}
+      {% endapi-method-path-parameters %}
+    {% endapi-method-request %}
 
-{% api-method-response %}
-{% api-method-response-example httpCode=200 %}
-{% api-method-response-example-description %}
+    {% api-method-response %}
+      {% api-method-response-example httpCode=200 %}
+        {% api-method-response-example-description %}
 
-{% endapi-method-response-example-description %}
+        {% endapi-method-response-example-description %}
 
-```
+        ```
 
-```
-{% endapi-method-response-example %}
-{% endapi-method-response %}
-{% endapi-method-spec %}
+        ```
+      {% endapi-method-response-example %}
+    {% endapi-method-response %}
+  {% endapi-method-spec %}
 {% endapi-method %}
 
 {% api-method method="post" host="https://api.streamelements.com" path="/kappa/v2/songrequest/:channel/replay" %}
-{% api-method-summary %}
-Replay a song from the history
-{% endapi-method-summary %}
+  {% api-method-summary %}
+    Replay a song from the history
+  {% endapi-method-summary %}
 
-{% api-method-description %}
+  {% api-method-description %}
 
-{% endapi-method-description %}
+  {% endapi-method-description %}
 
-{% api-method-spec %}
-{% api-method-request %}
-{% api-method-path-parameters %}
-{% api-method-parameter name="" type="string" required=false %}
+  {% api-method-spec %}
+    {% api-method-request %}
+      {% api-method-path-parameters %}
+        {% api-method-parameter name="" type="string" required=false %}
 
-{% endapi-method-parameter %}
-{% endapi-method-path-parameters %}
-{% endapi-method-request %}
+        {% endapi-method-parameter %}
+      {% endapi-method-path-parameters %}
+    {% endapi-method-request %}
 
-{% api-method-response %}
-{% api-method-response-example httpCode=200 %}
-{% api-method-response-example-description %}
+    {% api-method-response %}
+      {% api-method-response-example httpCode=200 %}
+        {% api-method-response-example-description %}
 
-{% endapi-method-response-example-description %}
+        {% endapi-method-response-example-description %}
 
-```
+        ```
 
-```
-{% endapi-method-response-example %}
-{% endapi-method-response %}
-{% endapi-method-spec %}
+        ```
+      {% endapi-method-response-example %}
+    {% endapi-method-response %}
+  {% endapi-method-spec %}
 {% endapi-method %}
 
 {% api-method method="get" host="https://api.streamelements.com" path="/kappa/v2/songrequest/:channel/next" %}
-{% api-method-summary %}
-Get the next song in the queue
-{% endapi-method-summary %}
+  {% api-method-summary %}
+    Get the next song in the queue
+  {% endapi-method-summary %}
 
-{% api-method-description %}
+  {% api-method-description %}
 
-{% endapi-method-description %}
+  {% endapi-method-description %}
 
-{% api-method-spec %}
-{% api-method-request %}
-{% api-method-path-parameters %}
-{% api-method-parameter name="" type="string" required=false %}
+  {% api-method-spec %}
+    {% api-method-request %}
+      {% api-method-path-parameters %}
+        {% api-method-parameter name="" type="string" required=false %}
 
-{% endapi-method-parameter %}
-{% endapi-method-path-parameters %}
-{% endapi-method-request %}
+        {% endapi-method-parameter %}
+      {% endapi-method-path-parameters %}
+    {% endapi-method-request %}
 
-{% api-method-response %}
-{% api-method-response-example httpCode=200 %}
-{% api-method-response-example-description %}
+    {% api-method-response %}
+      {% api-method-response-example httpCode=200 %}
+        {% api-method-response-example-description %}
 
-{% endapi-method-response-example-description %}
+        {% endapi-method-response-example-description %}
 
-```
+        ```
 
-```
-{% endapi-method-response-example %}
-{% endapi-method-response %}
-{% endapi-method-spec %}
+        ```
+      {% endapi-method-response-example %}
+    {% endapi-method-response %}
+  {% endapi-method-spec %}
 {% endapi-method %}
-


### PR DESCRIPTION
I was going to contribute the volume endpoint documentation, but I found it rather hard to read with everything at a single level of indentation. This should make it easier to parse for humans, but I'm worried the machine parser won't understand what's going on.

If it does work let me know, if not that's fine.

The program I wrote to handle do this automatically:

``` ruby
leads = {
  "api-method" => 0,
  "api-method-summary" => 2,
  "api-method-description" => 2,
  "api-method-spec" => 2,
  "api-method-request" => 4,
  "api-method-path-parameters" => 6,
  "api-method-body-parameters" => 6,
  "api-method-parameter" => 8,
  "api-method-headers" => 6,
  "api-method-response" => 4,
  "api-method-response-example" => 6,
  "api-method-response-example-description" => 8,
  "endapi-method" => 0,
  "endapi-method-summary" => 2,
  "endapi-method-description" => 2,
  "endapi-method-spec" => 2,
  "endapi-method-request" => 4,
  "endapi-method-path-parameters" => 6,
  "endapi-method-body-parameters" => 6,
  "endapi-method-parameter" => 8,
  "endapi-method-headers" => 6,
  "endapi-method-response" => 4,
  "endapi-method-response-example" => 6,
  "endapi-method-response-example-description" => 8
}

File.write("songrequest.md", File.read("songrequest.md").split("\n").map do |line|
  if !line.match?(/^\s+/) && line.match?(/#{leads.keys.join("|")}/)
    " " * (leads.fetch(line.match(/\{\% ([\w-]+).+/)[1])) + line
  else
    line
  end
end.join("\n"))
```

It's idempotent so you can run it multiple times on the same document.